### PR TITLE
Install Kaixa in Include/scripts/groovy

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,14 @@ print.savePrompt(prompt);
 module.exports = () => {
   const targetFilename = path.join(
     process.env.PWD,
-    'Keywords/Kaixa.groovy'
+    'Include/scripts/groovy/Kaixa.groovy'
   );
   const updating = fs.existsSync(targetFilename);
 
   // Make sure we're in a Katalon project
   if (
     !fs.existsSync(path.join(process.env.PWD, 'Keywords'))
+    || !fs.existsSync(path.join(process.env.PWD, 'Include'))
     || !fs.existsSync(path.join(process.env.PWD, 'Profiles'))
     || !fs.existsSync(path.join(process.env.PWD, 'Drivers'))
     || !fs.existsSync(path.join(process.env.PWD, 'Test Cases'))
@@ -71,10 +72,10 @@ module.exports = () => {
   if (updating) {
     console.log(`We updated to Kaixa version ${packageJSON.version} for this project.\n`);
     console.log('What to do next:');
-    console.log('In a text editor, open Keywords/default/Kaixa.groovy and check the version.');
+    console.log('In a text editor, open Include/scripts/groovy/Kaixa.groovy and check the version.');
   } else {
     console.log(`We added Kaixa version ${packageJSON.version} to this project.\n`);
     console.log('What to do next:');
-    console.log('In Katalon, make sure there is a Keywords/default/Kaixa.groovy file but do not open it.');
+    console.log('In Katalon, make sure there is a Include/scripts/groovy/Kaixa.groovy file but do not open it.');
   }
 };


### PR DESCRIPTION
With newer versions of Katalon, the Keywords directory is not accessible anymore in the free version. But Kaixa works fine in the Include/scripts directory, which is probably where it should have always been.
I haven't tested this :)