### PR TITLE
Added new functionality to getContentsXPath to support more CSS selectors.

### DIFF
--- a/src/Kaixa.groovy
+++ b/src/Kaixa.groovy
@@ -572,6 +572,8 @@ public class Kaixa {
 	 * All Child Elements of p: "p > *"
 	 * Element By ID: "#foo"
 	 * Element By Class: ".foo"
+	 * All Child Elements of element by ID or Class: "#foo > *", ".foo > *"
+	 * All Child Divs of element by ID or Class: "#foo > div", ".foo > div"
 	 * Element With Attribute: "*[title]", "a[title='foo']"
 	 * First Child of P: "p > *:first-child"
 	 * Next Element after P: "p + *"
@@ -580,19 +582,21 @@ public class Kaixa {
 	public static String getContentsXPath(Object contents, String selector) {
 		// Generate the start of the xpath
 		String start = '*';
-		if (selector.startsWith('#')) {
-			// id
-			start = '*[@id=\'' + selector.substring(1) + '\']';
-		} else if (selector.startsWith('.')) {
-			// Class selector
-			String[] parts = selector.split(Pattern.quote(" "));
-			String baseClass = parts[0].substring(1); // Extract class name
-
-			if (selector.contains(">")) {
-				// Class with child selector (e.g., .foo > *)
-				start = "[contains(@class, '" + baseClass + "')]/";
+		// Gets id and class selectors
+		if (selector.startsWith("#") || selector.startsWith(".")) {
+			// Find the attribute name
+			String[] selectorParts = selector.split(Pattern.quote(" "));
+			String identifier = selectorParts[0].substring(1); 
+			// Add to xpath
+			if (selector.startsWith("#")) {
+				start = "*[@id='" + identifier + "']";
 			} else {
-				start = "*[contains(@class, '" + baseClass + "')]";
+				start = "*[contains(@class, '" + identifier + "')]";
+			}
+			// If there are more parts, add them to the xpath
+			if (selectorParts.length > 2 && selectorParts[1].startsWith(">")) {
+				// Find the child element
+				start += "/descendant::" + selectorParts[2];
 			}
 		} else if (selector.startsWith('*[')) {
 			// element with attribute


### PR DESCRIPTION
It now supports css selectors of this type
.className > *, div, p, etc.
#id > *, div, p, etc.

Tested against my respond activity tests. So far no issues as long as the selector is formatted with space delimiters. 